### PR TITLE
Allowed JSON customization

### DIFF
--- a/tests/formatters/json/test_extended_json_formatter.py
+++ b/tests/formatters/json/test_extended_json_formatter.py
@@ -6,11 +6,7 @@ from unittest.mock import patch, ANY
 
 from freezegun import freeze_time
 
-from aiologger.formatters.json import (
-    ExtendedJsonFormatter,
-    LOG_LEVEL_FIELDNAME,
-    LINE_NUMBER_FIELDNAME,
-)
+from aiologger.formatters.json import ExtendedJsonFormatter
 from aiologger.records import ExtendedLogRecord
 
 
@@ -35,15 +31,28 @@ class ExtendedJsonFormatterTests(unittest.TestCase):
         self
     ):
         formatter = ExtendedJsonFormatter()
-        self.assertEqual(
-            ExtendedJsonFormatter.default_fields, formatter.log_fields
+        self.assertSetEqual(
+            formatter.log_fields,
+            {
+                ExtendedJsonFormatter.LOG_LEVEL_FIELDNAME,
+                ExtendedJsonFormatter.LOGGED_AT_FIELDNAME,
+                ExtendedJsonFormatter.LINE_NUMBER_FIELDNAME,
+                ExtendedJsonFormatter.FUNCTION_NAME_FIELDNAME,
+                ExtendedJsonFormatter.FILE_PATH_FIELDNAME,
+            }
         )
+
 
     def test_default_log_fields_can_be_excluded_with_exclude_fields_initialization_argument(
         self
     ):
-        formatter = ExtendedJsonFormatter(exclude_fields=(LOG_LEVEL_FIELDNAME,))
-        self.assertNotIn(LOG_LEVEL_FIELDNAME, formatter.log_fields)
+        formatter = ExtendedJsonFormatter(
+            exclude_fields=(ExtendedJsonFormatter.LOG_LEVEL_FIELDNAME,)
+        )
+        self.assertNotIn(
+            ExtendedJsonFormatter.LOG_LEVEL_FIELDNAME,
+            formatter.log_fields,
+        )
 
     def test_formatter_fields_for_record_with_default_fields(self):
         result = dict(self.formatter.formatter_fields_for_record(self.record))
@@ -115,7 +124,10 @@ class ExtendedJsonFormatterTests(unittest.TestCase):
         )
 
     def test_formatter_fields_for_record_with_excluded_fields(self):
-        log_fields = {LOG_LEVEL_FIELDNAME, LINE_NUMBER_FIELDNAME}
+        log_fields = {
+            ExtendedJsonFormatter.LOG_LEVEL_FIELDNAME,
+            ExtendedJsonFormatter.LINE_NUMBER_FIELDNAME,
+        }
 
         with patch.object(self.formatter, "log_fields", log_fields):
             result = dict(

--- a/tests/loggers/test_json_logger.py
+++ b/tests/loggers/test_json_logger.py
@@ -10,10 +10,7 @@ from asynctest import CoroutineMock
 from aiologger.levels import LogLevel
 from aiologger.loggers.json import JsonLogger
 from aiologger.records import ExtendedLogRecord
-from aiologger.formatters.json import (
-    FUNCTION_NAME_FIELDNAME,
-    LOG_LEVEL_FIELDNAME,
-)
+from aiologger.formatters.json import JsonFormatter
 from aiologger.utils import CallableWrapper
 from freezegun import freeze_time
 
@@ -331,11 +328,20 @@ class JsonLoggerTests(asynctest.TestCase):
     async def test_default_fields_are_excludeable(self):
         logger = JsonLogger.with_default_handlers(
             level=10,
-            exclude_fields=[FUNCTION_NAME_FIELDNAME, LOG_LEVEL_FIELDNAME],
+            exclude_fields=[
+                JsonFormatter.FUNCTION_NAME_FIELDNAME,
+                JsonFormatter.LOG_LEVEL_FIELDNAME
+            ],
         )
 
         await logger.info("Xablau")
         logged_content = json.loads(await self.stream_reader.readline())
 
-        self.assertNotIn(FUNCTION_NAME_FIELDNAME, logged_content)
-        self.assertNotIn(LOG_LEVEL_FIELDNAME, logged_content)
+        self.assertNotIn(
+            JsonFormatter.FUNCTION_NAME_FIELDNAME,
+            logged_content,
+        )
+        self.assertNotIn(
+            JsonFormatter.LOG_LEVEL_FIELDNAME,
+            logged_content,
+        )


### PR DESCRIPTION
Some software stacks are a little opinionated about the names of fields in structured logs. This Pull Requests allows to customize these names in a declarative way by subclassing the JsonFormatter or ExtendedJsonFormatter.

A new formatter called EcsExtendedJsonFormatter was added both as a PoC for this feature and as a directly usable way to get Elastic Common Schema-compliant logging.