### PR TITLE
Add support for positional formatting arguments

### DIFF
--- a/aiologger/records.py
+++ b/aiologger/records.py
@@ -5,7 +5,7 @@ import os
 import time
 import types
 from collections.abc import Mapping
-from typing import Optional, Tuple, Type
+from typing import Optional, Tuple, Type, Union
 
 from aiologger.levels import LogLevel, get_level_name
 
@@ -32,7 +32,7 @@ class LogRecord:
         pathname: str,
         lineno: int,
         msg,
-        args: Optional[Tuple[Mapping]] = None,
+        args: Optional[Tuple] = None,
         exc_info: Optional[ExceptionInfo] = None,
         func: Optional[str] = None,
         sinfo: Optional[str] = None,
@@ -65,13 +65,8 @@ class LogRecord:
         created_at = time.time()
         self.name = name
         self.msg = msg
-        self.args: Optional[Mapping]
-        if args:
-            if len(args) != 1 or not isinstance(args[0], Mapping):
-                raise ValueError(
-                    f"Invalid LogRecord args type: {type(args[0])}. "
-                    f"Expected Mapping"
-                )
+        self.args: Optional[Union[Mapping, Tuple]]
+        if args and len(args) == 1 and isinstance(args[0], Mapping) and args[0]:
             self.args = args[0]
         else:
             self.args = args

--- a/tests/handlers/test_files.py
+++ b/tests/handlers/test_files.py
@@ -347,10 +347,7 @@ class AsyncTimedRotatingFileHandlerTests(asynctest.TestCase):
         with freeze_time("2019-01-20 20:22:49") as frozen_datetime:
             with patch(
                 "aiologger.handlers.files.os.stat",
-                return_value=Mock(
-                    st_mtime=frozen_datetime.time_to_freeze.timestamp()
-                    - time.altzone
-                ),
+                return_value=Mock(st_mtime=time.time()),
             ), patch("aiologger.handlers.files.os.unlink") as unlink:
                 new_file_path = f"{self.temp_file.name}.2019-01-20_20-22-49"
                 os.open(new_file_path, os.O_CREAT)

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -27,7 +27,7 @@ class LogRecordTests(unittest.TestCase):
         )
         self.assertEqual(record.get_message(), "Hello world!")
 
-    def test_get_message_with_args(self):
+    def test_get_message_with_args_mapping(self):
         record = LogRecord(
             name="name",
             level=LogLevel.INFO,
@@ -38,16 +38,16 @@ class LogRecordTests(unittest.TestCase):
         )
         self.assertEqual(record.get_message(), "Dog: Xablau")
 
-    def test_it_validates_log_record_args(self):
-        with self.assertRaises(ValueError):
-            LogRecord(
-                name="name",
-                level=LogLevel.INFO,
-                pathname=__file__,
-                lineno=666,
-                msg="Dog: %(dog_name)s",
-                args=(1, 2, 3),
-            )
+    def test_get_message_with_positional_args(self):
+        record = LogRecord(
+            name="name",
+            level=LogLevel.INFO,
+            pathname=__file__,
+            lineno=666,
+            msg="Dog: %s",
+            args=("Xablau",),
+        )
+        self.assertEqual(record.get_message(), "Dog: Xablau")
 
     def test_str_representation(self):
         record = LogRecord(


### PR DESCRIPTION
An old unresolved issue (https://github.com/b2wdigital/aiologger/issues/97).
Python's logging library supports positional formatting arguments and not only mapping arguments.
I added support for this in aiologger, more details are in the commit messages.

I also fixed 2 tests which were failing both on my PC and in CI.